### PR TITLE
Allow initialization of y without cgls

### DIFF
--- a/src/method.jl
+++ b/src/method.jl
@@ -52,7 +52,7 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
             max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
-            subsolver_logger :: AbstractLogger=NullLogger(),
+            subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
            )
   if nlp.meta.ncon == 0 || !equality_constrained(nlp)
     error("percival(::Val{:equ}, nlp) should only be called for equality-constrained problems with bounded variables. Use percival(nlp)")
@@ -74,9 +74,9 @@ function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.
   
 
   # Lagrange multiplier
-  y = with_logger(subsolver_logger) do
+  y = inity === nothing ? with_logger(subsolver_logger) do
     cgls(Jx', gx)[1]
-  end
+  end : inity
   # tolerance
   η = 0.5
   ω = 1.0

--- a/src/method.jl
+++ b/src/method.jl
@@ -48,6 +48,7 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 - max_time: Maximum elapsed time in seconds (default: 30.0)
 - max_eval: Maximum number of objective function evaluations (default: 100000)
 - subsolver_logger: Logger passed to `tron` (default: NullLogger)
+- inity: Initial values of the Lagrangian multipliers
 """
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
             max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,


### PR DESCRIPTION
`cgls` requires both the `J v` and `J' v` operators. However, arguably the main benefit of the augmented Lagrangian algorithm is for problems where there exists an efficient `J' v` operator. Often the opposite may not be true. From what I can tell, `cgls` is only used to initialize the duals so one can choose to initialize these manually instead to bypass `cgls`. This PR allows that.