### PR TITLE
Allow lbfgs on auglag, expose more kwargs and fix max_eval

### DIFF
--- a/src/method.jl
+++ b/src/method.jl
@@ -54,7 +54,8 @@ function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.
             max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
-            subproblem_modifier = identity, max_cgiter = nlp.meta.nvar, subsolver_max_eval = max_eval,
+            subproblem_modifier = identity, subsolver_max_eval = max_eval,
+            subsolver_kwargs = Dict(:max_cgiter => nlp.meta.nvar),
            )
   if nlp.meta.ncon == 0 || !equality_constrained(nlp)
     error("percival(::Val{:equ}, nlp) should only be called for equality-constrained problems with bounded variables. Use percival(nlp)")
@@ -112,7 +113,12 @@ function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.
   while !(solved || infeasible || tired)
     # solve subproblem
     S = with_logger(subsolver_logger) do
-      tron(subproblem_modifier(al_nlp), x=copy(al_nlp.x), cgtol=ω, rtol=ω, atol=ω, max_time=max_time-el_time, max_eval=min(subsolver_max_eval, rem_eval), max_cgiter=max_cgiter)
+      tron(
+        subproblem_modifier(al_nlp); x = copy(al_nlp.x), cgtol = ω, rtol = ω,
+        atol = ω, max_time = max_time - el_time,
+        max_eval = min(subsolver_max_eval, rem_eval),
+        subsolver_kwargs...,
+      )
     end
     inner_status = S.status
 

--- a/src/method.jl
+++ b/src/method.jl
@@ -16,7 +16,7 @@ end
 
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
                   max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int = 100000,
-                  atol :: Real = 1e-8, rtol :: Real = 1e-8, modifier = identity,
+                  atol :: Real = 1e-8, rtol :: Real = 1e-8, subproblem_modifier = identity,
                   subsolver_logger :: AbstractLogger=NullLogger(), max_cgiter ::Int = nlp.meta.nvar
                  )
   if !(unconstrained(nlp) || bound_constrained(nlp))

--- a/src/method.jl
+++ b/src/method.jl
@@ -17,13 +17,18 @@ end
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
                   max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 200000,
                   atol :: Real = 1e-8, rtol :: Real = 1e-8, subproblem_modifier = identity,
-                  subsolver_logger :: AbstractLogger = NullLogger(), max_cgiter ::Int = nlp.meta.nvar
-                 )
+                  subsolver_logger :: AbstractLogger = NullLogger(),
+                  subsolver_kwargs = Dict(:max_cgiter => nlp.meta.nvar),
+                  )
   if !(unconstrained(nlp) || bound_constrained(nlp))
     error("percival(::Val{:tron}, nlp) should only be called for unconstrained or bound-constrained problems. Use percival(nlp)")
   end
   @warn "Problem does not have general constraints; calling tron"
-  return tron(subproblem_modifier(nlp), subsolver_logger=subsolver_logger, atol=atol, rtol=rtol, max_eval=max_eval, max_time=max_time, max_cgiter = max_cgiter)
+  return tron(
+    subproblem_modifier(nlp); subsolver_logger = subsolver_logger,
+    atol = atol, rtol = rtol, max_eval = max_eval, max_time = max_time,
+    subsolver_kwargs...,
+  )
 end
 
 function percival(::Val{:ineq}, nlp :: AbstractNLPModel; kwargs...)

--- a/src/method.jl
+++ b/src/method.jl
@@ -49,9 +49,10 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 - max_eval: Maximum number of objective function evaluations (default: 100000)
 - subsolver_logger: Logger passed to `tron` (default: NullLogger)
 - inity: Initial values of the Lagrangian multipliers
+- subsolver_kwargs: subsolver keyword arguments as a dictionary
 """
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
-            max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=200000,
+            max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int=200000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
             subproblem_modifier = identity, subsolver_max_eval = max_eval,

--- a/src/method.jl
+++ b/src/method.jl
@@ -15,7 +15,7 @@ function percival(nlp :: AbstractNLPModel; kwargs...)
 end
 
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
-                  max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 100000,
+                  max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int = 100000,
                   atol :: Real = 1e-8, rtol :: Real = 1e-8, modifier = identity,
                   subsolver_logger :: AbstractLogger=NullLogger(), max_cgiter ::Int = nlp.meta.nvar
                  )
@@ -51,7 +51,7 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 - inity: Initial values of the Lagrangian multipliers
 """
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
-            max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int=100000,
+            max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
             modifier = identity, max_cgiter = nlp.meta.nvar, tron_max_eval = max_eval,

--- a/src/method.jl
+++ b/src/method.jl
@@ -112,7 +112,7 @@ function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.
   while !(solved || infeasible || tired)
     # solve subproblem
     S = with_logger(subsolver_logger) do
-      tron(modifier(al_nlp), x=copy(al_nlp.x), cgtol=ω, rtol=ω, atol=ω, max_time=max_time-el_time, max_eval=min(tron_max_eval, rem_eval), max_cgiter=max_cgiter)
+      tron(subproblem_modifier(al_nlp), x=copy(al_nlp.x), cgtol=ω, rtol=ω, atol=ω, max_time=max_time-el_time, max_eval=min(subsolver_max_eval, rem_eval), max_cgiter=max_cgiter)
     end
     inner_status = S.status
 

--- a/src/method.jl
+++ b/src/method.jl
@@ -15,9 +15,9 @@ function percival(nlp :: AbstractNLPModel; kwargs...)
 end
 
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
-                  max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 100000,
+                  max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 200000,
                   atol :: Real = 1e-8, rtol :: Real = 1e-8, subproblem_modifier = identity,
-                  subsolver_logger :: AbstractLogger=NullLogger(), max_cgiter ::Int = nlp.meta.nvar
+                  subsolver_logger :: AbstractLogger = NullLogger(), max_cgiter ::Int = nlp.meta.nvar
                  )
   if !(unconstrained(nlp) || bound_constrained(nlp))
     error("percival(::Val{:tron}, nlp) should only be called for unconstrained or bound-constrained problems. Use percival(nlp)")

--- a/src/method.jl
+++ b/src/method.jl
@@ -15,7 +15,7 @@ function percival(nlp :: AbstractNLPModel; kwargs...)
 end
 
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
-                  max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int = 100000,
+                  max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 100000,
                   atol :: Real = 1e-8, rtol :: Real = 1e-8, subproblem_modifier = identity,
                   subsolver_logger :: AbstractLogger=NullLogger(), max_cgiter ::Int = nlp.meta.nvar
                  )
@@ -51,7 +51,7 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 - inity: Initial values of the Lagrangian multipliers
 """
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
-            max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
+            max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=200000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
             subproblem_modifier = identity, subsolver_max_eval = max_eval,

--- a/src/method.jl
+++ b/src/method.jl
@@ -15,7 +15,7 @@ function percival(nlp :: AbstractNLPModel; kwargs...)
 end
 
 function percival(::Val{:tron}, nlp :: AbstractNLPModel;
-                  max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int = 100000,
+                  max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int = 100000,
                   atol :: Real = 1e-8, rtol :: Real = 1e-8, modifier = identity,
                   subsolver_logger :: AbstractLogger=NullLogger(), max_cgiter ::Int = nlp.meta.nvar
                  )
@@ -51,7 +51,7 @@ Implementation of an augmented Lagrangian method. The following keyword paramete
 - inity: Initial values of the Lagrangian multipliers
 """
 function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.meta.x0)(10.0),
-            max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
+            max_iter :: Int = 2000, max_time :: Real = 30.0, max_eval :: Int=100000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
             modifier = identity, max_cgiter = nlp.meta.nvar, tron_max_eval = max_eval,

--- a/src/method.jl
+++ b/src/method.jl
@@ -54,7 +54,7 @@ function percival(::Val{:equ}, nlp :: AbstractNLPModel; μ :: Real = eltype(nlp.
             max_iter :: Int = 1000, max_time :: Real = 30.0, max_eval :: Int=100000,
             atol :: Real = 1e-8, rtol :: Real = 1e-8, ctol :: Real = 1e-8,
             subsolver_logger :: AbstractLogger=NullLogger(), inity = nothing,
-            modifier = identity, max_cgiter = nlp.meta.nvar, tron_max_eval = max_eval,
+            subproblem_modifier = identity, max_cgiter = nlp.meta.nvar, subsolver_max_eval = max_eval,
            )
   if nlp.meta.ncon == 0 || !equality_constrained(nlp)
     error("percival(::Val{:equ}, nlp) should only be called for equality-constrained problems with bounded variables. Use percival(nlp)")

--- a/src/method.jl
+++ b/src/method.jl
@@ -23,7 +23,7 @@ function percival(::Val{:tron}, nlp :: AbstractNLPModel;
     error("percival(::Val{:tron}, nlp) should only be called for unconstrained or bound-constrained problems. Use percival(nlp)")
   end
   @warn "Problem does not have general constraints; calling tron"
-  return tron(modifier(nlp), subsolver_logger=subsolver_logger, atol=atol, rtol=rtol, max_eval=max_eval, max_time=max_time, max_cgiter = max_cgiter)
+  return tron(subproblem_modifier(nlp), subsolver_logger=subsolver_logger, atol=atol, rtol=rtol, max_eval=max_eval, max_time=max_time, max_cgiter = max_cgiter)
 end
 
 function percival(::Val{:ineq}, nlp :: AbstractNLPModel; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ function test()
                               ]
       nlp = ADNLPModel(f, x0, c, zeros(m), zeros(m))
       output = with_logger(NullLogger()) do
-        percival(nlp, rtol = 1e-6)
+        percival(nlp)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -48,7 +48,7 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-6)
+        percival(nlp, modifier = modifier)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -92,7 +92,7 @@ function test()
                                           ]
       nlp = ADNLPModel(f, x0, lvar, uvar, c, zeros(m), zeros(m))
       output = with_logger(NullLogger()) do
-        percival(nlp, rtol = 1e-6)
+        percival(nlp)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -103,7 +103,7 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-6)
+        percival(nlp, modifier = modifier)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -147,7 +147,7 @@ function test()
                                           ]
       nlp = ADNLPModel(f, x0, c, lcon, ucon)
       output = with_logger(NullLogger()) do
-        percival(nlp, rtol = 1e-6)
+        percival(nlp)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -158,7 +158,7 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-6)
+        percival(nlp, modifier = modifier)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,8 +47,8 @@ function test()
 
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
-        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-5)
+        subproblem_modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, subproblem_modifier = subproblem_modifier, rtol = 1e-5)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-4)
@@ -102,8 +102,8 @@ function test()
 
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
-        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-5)
+        subproblem_modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, subproblem_modifier = subproblem_modifier, rtol = 1e-5)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-4)
@@ -157,8 +157,8 @@ function test()
 
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
-        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier, rtol = 1e-5)
+        subproblem_modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, subproblem_modifier = subproblem_modifier, rtol = 1e-5)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,12 +48,12 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         subproblem_modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, subproblem_modifier = subproblem_modifier, rtol = 1e-5)
+        percival(nlp, subproblem_modifier = subproblem_modifier, rtol = 1e-4)
       end
 
-      @test isapprox(output.solution, sol, rtol=1e-4)
-      @test output.primal_feas < 1e-4
-      @test output.dual_feas < 1e-4
+      @test isapprox(output.solution, sol, rtol=1e-3)
+      @test output.primal_feas < 1e-3
+      @test output.dual_feas < 1e-3
       @test output.status == :first_order
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,12 +48,12 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier)
+        percival(nlp, modifier = modifier, rtol = 1e-5)
       end
 
-      @test isapprox(output.solution, sol, rtol=1e-6)
-      @test output.primal_feas < 1e-6
-      @test output.dual_feas < 1e-6
+      @test isapprox(output.solution, sol, rtol=1e-4)
+      @test output.primal_feas < 1e-4
+      @test output.dual_feas < 1e-4
       @test output.status == :first_order
     end
   end
@@ -103,12 +103,12 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier)
+        percival(nlp, modifier = modifier, rtol = 1e-5)
       end
 
-      @test isapprox(output.solution, sol, rtol=1e-6)
-      @test output.primal_feas < 1e-6
-      @test output.dual_feas < 1e-6
+      @test isapprox(output.solution, sol, rtol=1e-4)
+      @test output.primal_feas < 1e-4
+      @test output.dual_feas < 1e-4
       @test output.status == :first_order
     end
   end
@@ -158,12 +158,12 @@ function test()
       # LBFGS approximation of the augmented Lagrangian
       output = with_logger(NullLogger()) do
         modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
-        percival(nlp, modifier = modifier)
+        percival(nlp, modifier = modifier, rtol = 1e-5)
       end
 
-      @test isapprox(output.solution, sol, rtol=1e-6)
-      @test output.primal_feas < 1e-6
-      @test output.dual_feas < 1e-6
+      @test isapprox(output.solution, sol, rtol=1e-4)
+      @test output.primal_feas < 1e-4
+      @test output.dual_feas < 1e-4
       @test output.status == :first_order
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
 using Percival
 
-using ADNLPModels, JSOSolvers, LinearAlgebra, Logging, SolverTest, SparseArrays, Test
+using ADNLPModels, JSOSolvers, LinearAlgebra, Logging, SolverTest, SparseArrays, NLPModelsModifiers, Test
 
 using NLPModels
 
 function test()
+  lbfgs_mem = 4
   @testset "Unconstrained tests" begin
     unconstrained_nlp(percival)
   end
@@ -36,7 +37,18 @@ function test()
                               ]
       nlp = ADNLPModel(f, x0, c, zeros(m), zeros(m))
       output = with_logger(NullLogger()) do
-        percival(nlp)
+        percival(nlp, rtol = 1e-6)
+      end
+
+      @test isapprox(output.solution, sol, rtol=1e-6)
+      @test output.primal_feas < 1e-6
+      @test output.dual_feas < 1e-6
+      @test output.status == :first_order
+
+      # LBFGS approximation of the augmented Lagrangian
+      output = with_logger(NullLogger()) do
+        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, modifier = modifier, rtol = 1e-6)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -80,7 +92,18 @@ function test()
                                           ]
       nlp = ADNLPModel(f, x0, lvar, uvar, c, zeros(m), zeros(m))
       output = with_logger(NullLogger()) do
-        percival(nlp)
+        percival(nlp, rtol = 1e-6)
+      end
+
+      @test isapprox(output.solution, sol, rtol=1e-6)
+      @test output.primal_feas < 1e-6
+      @test output.dual_feas < 1e-6
+      @test output.status == :first_order
+
+      # LBFGS approximation of the augmented Lagrangian
+      output = with_logger(NullLogger()) do
+        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, modifier = modifier, rtol = 1e-6)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -124,7 +147,18 @@ function test()
                                           ]
       nlp = ADNLPModel(f, x0, c, lcon, ucon)
       output = with_logger(NullLogger()) do
-        percival(nlp)
+        percival(nlp, rtol = 1e-6)
+      end
+
+      @test isapprox(output.solution, sol, rtol=1e-6)
+      @test output.primal_feas < 1e-6
+      @test output.dual_feas < 1e-6
+      @test output.status == :first_order
+
+      # LBFGS approximation of the augmented Lagrangian
+      output = with_logger(NullLogger()) do
+        modifier = m -> NLPModelsModifiers.LBFGSModel(m, mem = lbfgs_mem)
+        percival(nlp, modifier = modifier, rtol = 1e-6)
       end
 
       @test isapprox(output.solution, sol, rtol=1e-6)
@@ -133,7 +167,6 @@ function test()
       @test output.status == :first_order
     end
   end
-
 end
 
 test()


### PR DESCRIPTION
This PR does 3 things. Let me know if you prefer I split them.
- By introducing the `modifier` kwarg, one can now pass a function that changes the augmented Lagrangian model to an LBFGS model
- I exposed more kwargs from `tron` to `percival` to give more options to set.
- I made sure `max_eval` referred to the total number of function evaluations not for each loop iteration. Let me know if you think a different kwarg would be better here.