### PR TITLE
fix kwargs for tron

### DIFF
--- a/src/method.jl
+++ b/src/method.jl
@@ -28,6 +28,7 @@ function percival(
   subproblem_modifier = identity,
   subsolver_logger::AbstractLogger = NullLogger(),
   subsolver_kwargs = Dict(:max_cgiter => nlp.meta.nvar),
+  kwargs...,
 )
   if !(unconstrained(nlp) || bound_constrained(nlp))
     error(


### PR DESCRIPTION
Hello! I noticed that percival breaks when simultaneously given an unconstrained problem and keyword arguments referring to constraints. A simple example:
```
using Percival, CUTEst
nlp = CUTEstModel("JUDGE")
percival(nlp)
percival(nlp, ctol=1e-6)
finalize(nlp)
```
This tiny PR fixes it.