### PR TITLE
Correct display of norm_y

### DIFF
--- a/src/method.jl
+++ b/src/method.jl
@@ -388,7 +388,7 @@ function SolverCore.solve!(
           normgp,
           normcx,
           al_nlp.μ,
-          norm(y),
+          norm(al_nlp.y),
           counter_cost(nlp),
           inner_status,
           iter_type,


### PR DESCRIPTION
Correcting `norm(y)` to `norm(al_nlp.y)` in `log_row()`.