### PR TITLE
Fix citation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use Percival, you have to pass it an [NLPModel](https://github.com/JuliaSmoot
 
 ## How to Cite
 
-If you use Percival.jl in your work, please cite using the format given in [CITATION.bib](CITATION.bib).
+If you use Percival.jl in your work, please cite using the format given in [CITATION.bib](https://github.com/JuliaSmoothOptimizers/Percival.jl/blob/main/CITATION.bib).
 
 ## Install
 


### PR DESCRIPTION
We're adding Percival to the JuMP docs: https://github.com/jump-dev/JuMP.jl/pull/3567.

This link works in the GitHub readme, but it doesn't work once it's in the JuMP documentation.