### PR TITLE
Fix math in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ pkg> add Percival
 
 Consider the following 2-dimensional optimization problem with an equality constraint
 
-$$
+```math
 \begin{equation}
 \min_{(x_1,x_2)} \quad (x_1 - 1)^2 + 100 (x_2 - x_1^2)^2 \quad \text{s.to} \quad x_1^2 + x_2^2 = 1.
 \end{equation}
-$$
+```
 
 You can solve an JuMP model `model` by using [NLPModelsJuMP.jl](https://github.com/JuliaSmoothOptimizers/NLPModelsJuMP.jl) to convert it.
 ```julia


### PR DESCRIPTION
It's currently broken in the JuMP docs: https://jump.dev/JuMP.jl/stable/packages/Percival/

![image](https://github.com/JuliaSmoothOptimizers/Percival.jl/assets/8177701/070ddfe0-ede0-4849-9596-c98abbb85e14)
